### PR TITLE
Typo fix and PEP8 improvements

### DIFF
--- a/examples/factorial.py
+++ b/examples/factorial.py
@@ -1,5 +1,5 @@
 #
-# Factorial example using stackless to break Python's recustion limit of 1000
+# Factorial example using stackless to break Python's recursion limit of 1000
 #
 # by Andrew Dalke
 #

--- a/examples/factorial.py
+++ b/examples/factorial.py
@@ -19,17 +19,22 @@
 import stackless
 import time
 
+
 def call_wrapper(f, args, kwargs, result_ch):
     result_ch.send(f(*args, **kwargs))
+
 
 def call(f, *args, **kwargs):
     result_ch = stackless.channel()
     stackless.tasklet(call_wrapper)(f, args, kwargs, result_ch)
     return result_ch.receive()
+
+
 def factorial(n):
     if n <= 1:
         return 1
     return n * call(factorial, n-1)
+
 
 st = time.time()
 

--- a/examples/factorial.py
+++ b/examples/factorial.py
@@ -23,7 +23,7 @@ def call_wrapper(f, args, kwargs, result_ch):
     result_ch.send(f(*args, **kwargs))
 
 def call(f, *args, **kwargs):
-    result_ch= stackless.channel()
+    result_ch = stackless.channel()
     stackless.tasklet(call_wrapper)(f, args, kwargs, result_ch)
     return result_ch.receive()
 def factorial(n):


### PR DESCRIPTION
Hi,

I was reading the factorial example, and noticed a typo in 'recustion'/'recursion', and then a couple of minor PEP8 non-compliances.

If you'd rather have a single blank line around functions than 2 no problem - it was the fact that `def factorial(n):` had no empty lines before it and the others had 1 that drew my eye. I'm not familiar with the codebase as a whole - a single line would match some other examples I found like [this one](https://github.com/stackless-dev/stacklessexamples/blob/main/examples/scheduleAlternative.py#L37), although [this one](https://github.com/stackless-dev/stacklessexamples/blob/main/examples/pickleChannels.py#L18) has two except for before the `Foo` class. I thought I'd limit my changes to this one file and seek your feedback - if you're keen I can make whitespace changes elsewhere for consistency.

Thanks for Stackless python and for these examples!